### PR TITLE
MSetNX should call ReadBool, not ReadOK


### DIFF
--- a/src/Sider/RedisClient.API.cs
+++ b/src/Sider/RedisClient.API.cs
@@ -456,7 +456,7 @@ namespace Sider
           w.WriteArg(kv.Key);
           w.WriteArg(_serializer, kv.Value);
         }),
-        r => r.ReadOk());
+        r => r.ReadBool());
     }
 
     public bool Set(string key, T value)


### PR DESCRIPTION
The method RedisClient.MSetNX currently calls ReadOK, expecting a SingleLine String reply from the server. This command always fails with an unhandled exception because the server invariably returns an Integer ("1" or "0") for this command. ReadBool parses this response in the intended fashion. I've verified through local tests that the command works correctly after this change. TODO: Perhaps a test suite could be implemented for unit tests of the RedisClient API versus a dummy server (in a private fork, at least, to avoid abuse).
