### PR TITLE
Remove "RESET" printout from RedisClientBase.

### DIFF
--- a/src/Sider/RedisClientBase.cs
+++ b/src/Sider/RedisClientBase.cs
@@ -61,8 +61,6 @@ namespace Sider
 
     public virtual void Reset()
     {
-      Debug.WriteLine("RESET");
-
       _disposing = _disposed = false;
       _socket = new Socket(AddressFamily.InterNetwork,
         SocketType.Stream, ProtocolType.Tcp);


### PR DESCRIPTION
Sider is no longer polluting stdout with unneccessary output each time a
RedisClient is constructed.