### PR TITLE
Update RedisClient.API.cs

### DIFF
--- a/src/Sider/RedisClient.API.cs
+++ b/src/Sider/RedisClient.API.cs
@@ -122,7 +122,7 @@ namespace Sider
 
         var result = new KeyValuePair<string, string>[rawResult.Length / 2];
         var resultIdx = 0;
-        for (var i = 0; i < rawResult.Length; i += 2)
+        for (var i = 0; i < rawResult.Length-1; i += 2)
           result[resultIdx++] = new KeyValuePair<string, string>(
             rawResult[i], rawResult[i + 1]);
 


### PR DESCRIPTION
Fixed below error  (Redis 2.8.11 version)

 Index was outside the bounds of the array.

Stack trace
at Sider.RedisClient`1.<Info>m__D(ProtocolReader r)
at Sider.RedisClient`1.<invoke>c__AnonStorey5B`1.<>m__1(ProtocolReader r)
at Sider.Executors.ExecutorBase.ExecuteImmediate[T](Invocation`1 invocation)
at Sider.Executors.ImmediateExecutor.execute[T](Invocation`1 invocation, Int32 retryCount)
at Sider.Executors.ImmediateExecutor.Execute[T](Invocation`1 invocation)
at Sider.RedisClient`1.invoke[TInv](Invocation`1 invocation)
at Sider.RedisClient`1.invoke[TInv](String command, Int32 numArgs, Action`1 writeArgsAction, Func`2 readAction)
at Sider.RedisClient`1.invoke[TInv](String command, Func`2 readAction)
at Sider.RedisClient`1.Info()