### PR TITLE
Correcting property name mentioned in Obsolete attribute on Settings builder

### DIFF
--- a/src/Sider/RedisSettings.cs
+++ b/src/Sider/RedisSettings.cs
@@ -250,7 +250,7 @@ namespace Sider
         return this;
       }
 
-      [Obsolete("Please use EncodingOverride instead.")]
+      [Obsolete("Please use OverrideEncoding instead.")]
       public Builder ValueEncoding(Encoding encoding)
       {
         SAssert.ArgumentNotNull(() => encoding);
@@ -259,7 +259,7 @@ namespace Sider
         return this;
       }
 
-      [Obsolete("Please use EncodingOverride instead.")]
+      [Obsolete("Please use OverrideEncoding instead.")]
       public Builder KeyEncoding(Encoding encoding)
       {
         SAssert.ArgumentNotNull(() => encoding);


### PR DESCRIPTION
Was referencing 'EncodingOverride', which is the name of the property on the settings class, but on the builder the method is called 'OverrideEncoding'.